### PR TITLE
Fix 'docker.sock: no such file or directory' error

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -9,7 +9,7 @@ apt_mirror='http://archive.ubuntu.com/ubuntu'
 docker_image="32bit/ubuntu:${1:-14.04}"
 
 ### make sure that the required tools are installed
-packages="debootstrap dchroot"
+packages="debootstrap dchroot apparmor"
 which docker || packages="$packages docker.io"
 apt-get install -y $packages
 


### PR DESCRIPTION
Docker requires the Ubuntu package 'apparmor' to be installed on the host
operating system for the Docker daemon to start. Without the docker service
running, line 53 of ubuntu/build-image.sh:

> 52. # import this tar archive into a docker image:
> 53. cat ubuntu.tgz | docker import - $docker_image

Fails with the following error message:

> FATA[0000] Post http:///var/run/docker.sock/v1.18/images/create?fromSrc=-&repo=32bit%2Fubuntu%3A14.04: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?

...with the /var/log/messages showing the docker service failing to start:

> Mar 20 11:20:05 [] kernel: [ 7882.885540] init: docker main process (16915) terminated with status 1
> Mar 20 11:20:05 [] kernel: [ 7882.885552] init: docker respawning too fast, stopped

This commit adds the package, which as of writing is available on all currently
supported distributions of Ubuntu [1].

More information on this issue can be found at [2] [3].

[1] http://packages.ubuntu.com/search?keywords=apparmor
[2] http://tekhead.it/2014/09/installing-docker-on-ubuntu-quick-fix/
[3] http://tekhead.it/blog/2014/09/docker-part-1-introduction-and-howto-install-docker-on-ubuntu-14-04-lts/