### PR TITLE
Use xenial (ubuntu 16.04) as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ ubuntu
 
 Build a docker image for ubuntu i386.
 
-Run `build-image.sh` to build the docker image `32bit/ubuntu:14.04`,
-or `build-image.sh precise` to build the docker image `32bit/ubuntu:precise`.
+Run `build-image.sh` to build the docker image `32bit/ubuntu:16.04`.
+
+To build other docker images that are lower version than xenial,
+run with target name like `build-image.sh trusty` to build the docker image `32bit/ubuntu:trusty`.
 
 See also: http://mwhiteley.com/linux-containers/2013/08/31/docker-on-i386.html

--- a/build-image.sh
+++ b/build-image.sh
@@ -3,10 +3,10 @@
 
 ### settings
 arch=i386
-suite=${1:-trusty}
+suite=${1:-xenial}
 chroot_dir="/var/chroot/$suite"
 apt_mirror='http://archive.ubuntu.com/ubuntu'
-docker_image="32bit/ubuntu:${1:-14.04}"
+docker_image="32bit/ubuntu:${1:-16.04}"
 
 ### make sure that the required tools are installed
 packages="debootstrap dchroot apparmor"
@@ -23,7 +23,7 @@ deb $apt_mirror $suite main restricted universe multiverse
 deb $apt_mirror $suite-updates main restricted universe multiverse
 deb $apt_mirror $suite-backports main restricted universe multiverse
 deb http://security.ubuntu.com/ubuntu $suite-security main restricted universe multiverse
-deb http://extras.ubuntu.com/ubuntu $suite main
+deb http://archive.ubuntu.com/ubuntu $suite main
 EOF
 
 ### install ubuntu-minimal


### PR DESCRIPTION
I guess there's no reason to keep using 14.04 as default.
This pull request updates script to use xenial (16.04) as default target.

additionally, due to extras.ubuntu.com is deprecated, use archive.ubuntu.com instead.

I confirmed the script can work on Ubuntu 16.04 32bit, running on virtual box on OSX El-Capitan.

I hope this helps to improve your repository :)
